### PR TITLE
Replace a number of example API keys with more obviously fake data to…

### DIFF
--- a/testing/resources/aws_config_with_multiple_sections.ini
+++ b/testing/resources/aws_config_with_multiple_sections.ini
@@ -1,12 +1,12 @@
 # file with AWS access key ids, AWS secret access keys and AWS session tokens in multiple sections
 [default]
-aws_access_key_id = AKIASLARTIBARTFAST11
-aws_secret_access_key = 7xebzorgm5143ouge9gvepxb2z70bsb2rtrh099e
+aws_access_key_id = AKIAEXAMPLEKEY111111
+aws_secret_access_key = 7xebzorgm5143ouge9gvepxb2z70bsb2rexample
 [production]
-aws_access_key_id = AKIAVOGONSVOGONS0042
-aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6hcfozlb
+aws_access_key_id = AKIAEXAMPLEKEY222222
+aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6example
 [staging]
-aws_access_key_id = AKIAJIMMINYCRICKET0A
-aws_secret_access_key = ixswosj8gz3wuik405jl9k3vdajsnxfhnpui38ez
+aws_access_key_id = AKIAEXAMPLEKEY333333
+aws_secret_access_key = ixswosj8gz3wuik405jl9k3vdajsnxfhnexample
 [test]
 aws_session_token = foo

--- a/testing/resources/aws_config_with_secret.ini
+++ b/testing/resources/aws_config_with_secret.ini
@@ -1,4 +1,4 @@
 # file with an AWS access key id and an AWS secret access key
 [production]
-aws_access_key_id = AKIAVOGONSVOGONS0042
-aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6hcfozlb
+aws_access_key_id = AKIAEXAMPLEKEY222222
+aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6example

--- a/testing/resources/aws_config_with_secret_and_session_token.ini
+++ b/testing/resources/aws_config_with_secret_and_session_token.ini
@@ -1,5 +1,5 @@
 # file with an AWS access key id, an AWS secret access key and an AWS session token
 [production]
-aws_access_key_id = AKIAVOGONSVOGONS0042
-aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6hcfozlb
+aws_access_key_id = AKIAEXAMPLEKEY222222
+aws_secret_access_key = z2rpgs5uit782eapz5l1z0y2lurtsyyk6example
 aws_session_token = foo

--- a/testing/resources/aws_config_without_secrets.ini
+++ b/testing/resources/aws_config_without_secrets.ini
@@ -1,3 +1,3 @@
 # file with an AWS access key id but no AWS secret access key
 [production]
-aws_access_key_id = AKIASLARTIBARTFAST11
+aws_access_key_id = AKIAEXAMPLEKEY111111

--- a/testing/resources/aws_config_without_secrets_with_spaces.ini
+++ b/testing/resources/aws_config_without_secrets_with_spaces.ini
@@ -1,4 +1,4 @@
 # file with an AWS access key id but no valid AWS secret access key only space characters
 [production]
-aws_access_key_id = AKIASLARTARGENTINA86
+aws_access_key_id = AKIAEXAMPLEKEY444444
 aws_secret_access_key =


### PR DESCRIPTION
… remove any doubt/prevent false positives during audit.

I was auditing CRUK github code for stray API keys and these flagged up a false positive at first, until I checked them out more closely and realised they were fake data. This is just a small PR to hopefully prevent this happening again in the future. 